### PR TITLE
Set3DSoundSettings : Enable to specify global distance unit

### DIFF
--- a/demo/Scripts/FMOD.gd
+++ b/demo/Scripts/FMOD.gd
@@ -196,4 +196,7 @@ func sound_get_pitch(uuid):
 	
 func sound_set_pitch(uuid, pitch):
 	return FMOD.sound_set_pitch(uuid, pitch)
+
+func set_sound_3d_settings(dopplerScale, distanceFactor, rollOffScale):
+    return FMOD.set_sound_3d_settings(dopplerScale, distanceFactor, rollOffScale)
 	

--- a/demo/Scripts/FMOD.gd
+++ b/demo/Scripts/FMOD.gd
@@ -198,5 +198,5 @@ func sound_set_pitch(uuid, pitch):
 	return FMOD.sound_set_pitch(uuid, pitch)
 
 func system_set_sound_3d_settings(dopplerScale, distanceFactor, rollOffScale):
-    return FMOD.set_sound_3d_settings(dopplerScale, distanceFactor, rollOffScale)
+    return FMOD.system_set_sound_3d_settings(dopplerScale, distanceFactor, rollOffScale)
 	

--- a/demo/Scripts/FMOD.gd
+++ b/demo/Scripts/FMOD.gd
@@ -197,6 +197,6 @@ func sound_get_pitch(uuid):
 func sound_set_pitch(uuid, pitch):
 	return FMOD.sound_set_pitch(uuid, pitch)
 
-func set_sound_3d_settings(dopplerScale, distanceFactor, rollOffScale):
+func system_set_sound_3d_settings(dopplerScale, distanceFactor, rollOffScale):
     return FMOD.set_sound_3d_settings(dopplerScale, distanceFactor, rollOffScale)
 	

--- a/godot_fmod.cpp
+++ b/godot_fmod.cpp
@@ -783,7 +783,7 @@ void Fmod::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("sound_set_pitch", "uuid", "pitch"), &Fmod::setSoundPitch);
 	ClassDB::bind_method(D_METHOD("sound_get_pitch", "uuid"), &Fmod::getSoundPitch);
 
-	ClassDB::bind_method(D_METHOD("set_sound_3d_settings", "dopplerScale", "distanceFactor", "rollOffScale"), &Fmod::setSound3DSettings);
+	ClassDB::bind_method(D_METHOD("system_set_sound_3d_settings", "dopplerScale", "distanceFactor", "rollOffScale"), &Fmod::setSound3DSettings);
 
 	/* FMOD_INITFLAGS */
 	BIND_CONSTANT(FMOD_INIT_NORMAL);

--- a/godot_fmod.cpp
+++ b/godot_fmod.cpp
@@ -878,6 +878,7 @@ Fmod::Fmod() {
 	system = nullptr, coreSystem = nullptr, listener = nullptr;
 	checkErrors(FMOD::Studio::System::create(&system));
 	checkErrors(system->getCoreSystem(&coreSystem));
+	distanceScale = 1.0;
 }
 
 Fmod::~Fmod() {

--- a/godot_fmod.cpp
+++ b/godot_fmod.cpp
@@ -87,7 +87,8 @@ void Fmod::updateInstance3DAttributes(FMOD::Studio::EventInstance *instance, Obj
 		CanvasItem *ci = Object::cast_to<CanvasItem>(o);
 		if (ci != nullptr) {
 			Transform2D t2d = ci->get_transform();
-			Vector3 pos(t2d.get_origin().x, t2d.get_origin().y, 0.0f),
+			Vector2 posVector = t2d.get_origin() / distanceScale;
+			Vector3 pos(posVector.x, posVector.y, 0.0f),
 					up(0, 1, 0), forward(0, 0, 1), vel(0, 0, 0);
 			FMOD_3D_ATTRIBUTES attr = get3DAttributes(toFmodVector(pos), toFmodVector(up), toFmodVector(forward), toFmodVector(vel));
 			checkErrors(instance->set3DAttributes(&attr));
@@ -95,7 +96,7 @@ void Fmod::updateInstance3DAttributes(FMOD::Studio::EventInstance *instance, Obj
 			// needs testing
 			Spatial *s = Object::cast_to<Spatial>(o);
 			Transform t = s->get_transform();
-			Vector3 pos = t.get_origin();
+			Vector3 pos = t.get_origin() / distanceScale;
 			Vector3 up = t.get_basis().elements[1];
 			Vector3 forward = t.get_basis().elements[2];
 			Vector3 vel(0, 0, 0);
@@ -121,7 +122,8 @@ void Fmod::setListenerAttributes() {
 	CanvasItem *ci = Object::cast_to<CanvasItem>(listener);
 	if (ci != nullptr) {
 		Transform2D t2d = ci->get_transform();
-		Vector3 pos(t2d.get_origin().x, t2d.get_origin().y, 0.0f),
+		Vector2 posVector = t2d.get_origin() / distanceScale;
+		Vector3 pos(posVector.x, posVector.y, 0.0f),
 				up(0, 1, 0), forward(0, 0, 1), vel(0, 0, 0); // TODO: add doppler
 		FMOD_3D_ATTRIBUTES attr = get3DAttributes(toFmodVector(pos), toFmodVector(up), toFmodVector(forward), toFmodVector(vel));
 		checkErrors(system->setListenerAttributes(0, &attr));
@@ -130,7 +132,7 @@ void Fmod::setListenerAttributes() {
 		// needs testing
 		Spatial *s = Object::cast_to<Spatial>(listener);
 		Transform t = s->get_transform();
-		Vector3 pos = t.get_origin();
+		Vector3 pos = t.get_origin() / distanceScale;
 		Vector3 up = t.get_basis().elements[1];
 		Vector3 forward = t.get_basis().elements[2];
 		Vector3 vel(0, 0, 0);
@@ -698,6 +700,15 @@ void Fmod::releaseSound(const String &path) {
 	if (sound->value()) checkErrors(sound->value()->release());
 }
 
+void Fmod::setSound3DSettings(float dopplerScale, float distanceFactor, float rollOffScale) {
+	if (distanceFactor > 0 && checkErrors(coreSystem->set3DSettings(dopplerScale, distanceFactor, rollOffScale))) {
+		distanceScale = distanceFactor;
+		print_line("Successfully set global 3D settings");
+	} else {
+		print_error("FMOD Sound System: Failed to set 3D settings :|");
+	}
+}
+
 void Fmod::_bind_methods() {
 	/* system functions */
 	ClassDB::bind_method(D_METHOD("system_init", "num_of_channels", "studio_flags", "flags"), &Fmod::init);
@@ -771,6 +782,8 @@ void Fmod::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("sound_get_volume", "uuid"), &Fmod::getSoundVolume);
 	ClassDB::bind_method(D_METHOD("sound_set_pitch", "uuid", "pitch"), &Fmod::setSoundPitch);
 	ClassDB::bind_method(D_METHOD("sound_get_pitch", "uuid"), &Fmod::getSoundPitch);
+
+	ClassDB::bind_method(D_METHOD("set_sound_3d_settings", "dopplerScale", "distanceFactor", "rollOffScale"), &Fmod::setSound3DSettings);
 
 	/* FMOD_INITFLAGS */
 	BIND_CONSTANT(FMOD_INIT_NORMAL);

--- a/godot_fmod.h
+++ b/godot_fmod.h
@@ -50,6 +50,8 @@ class Fmod : public Object {
 	FMOD::Studio::System *system;
 	FMOD::System *coreSystem;
 
+	float distanceScale;
+
 	Object *listener;
 
 	bool nullListenerWarning = true;
@@ -157,6 +159,8 @@ public:
 	float getSoundVolume(const String &uuid);
 	float getSoundPitch(const String &uuid);
 	void setSoundPitch(const String &uuid, float pitch);
+
+	void setSound3DSettings(float dopplerScale, float distanceFactor, float rollOffScale);
 
 	Fmod();
 	~Fmod();


### PR DESCRIPTION
As Godot uses pixels, fmod is interpreting 1 meter per pixel.
This provide a wrapper method to set global distance unit parameter.

I currently have not tested it in engine, only compilation. It would be nice to test it before merging.
Same approach works with GDNative, it should not cause trouble to integrate.