### PR TITLE
Android build

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,50 @@ This module exposes most of the Studio API functions to Godot's GDScript and als
 
 FMOD should now be integrated. If you are tweaking/extending the module it is faster to compile it as a dynamic library instead of a static library. Refer to the Godot documentation for more details on this.
 
+### Android subtility
+
+In order to get fmod working on android, you need to make Fmod java static initialization in godot's android export
+template. To do so, follow the next steps :
+
+- Add fmod.jar as dependency in your project.
+In order to add fmod to gradle you should have dependencies looking like this :  
+```
+dependencies {
+	implementation "com.android.support:support-core-utils:28.0.0"
+	compile files("libs/fmod.jar")
+}
+```
+- Modify `onCreate` and `onDestroy` methods in `Godot` java class  
+
+For `onCreate` you should initialize java part of fmod. You should have something like this :  
+```java
+	@Override
+	protected void onCreate(Bundle icicle) {
+
+		super.onCreate(icicle);
+		FMOD.init(this);
+		Window window = getWindow();
+		...
+	}
+```
+
+For `onDestroy` method, you should close java part of Fmod. It should looks like this :
+```java
+	@Override
+	protected void onDestroy() {
+
+		if (mPaymentsManager != null) mPaymentsManager.destroy();
+		for (int i = 0; i < singleton_count; i++) {
+			singletons[i].onMainDestroy();
+		}
+		FMOD.close();
+		super.onDestroy();
+	}
+```
+
+- Then run `./gradlew build` to generate an apk export template. You can then use it in your project to get FMOD working
+on android.
+
 ## Using the module
 
 ### Basic usage

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ FMOD should now be integrated. If you are tweaking/extending the module it is fa
 
 ### Android subtility
 
+Before building the engine, you should first create the environment variable to get the NDK path.
+
+`export ANDROID_NDK_ROOT=pathToYourNDK`
+
 In order to get fmod working on android, you need to make Fmod java static initialization in godot's android export
 template. To do so, follow the next steps :
 

--- a/config.py
+++ b/config.py
@@ -1,5 +1,5 @@
 def can_build(env, platform):
-    return platform == "x11" or platform == "windows" or platform == "osx"
+    return platform == "x11" or platform == "windows" or platform == "osx" or platform == "android"
 
 
 def configure(env):
@@ -28,3 +28,10 @@ def configure(env):
         env.Append(LIBS=["fmod", "fmodstudio"])
         env.Append(
             LIBPATH=["#modules/fmod/api/core/lib/", "#modules/fmod/api/studio/lib/"])
+
+    elif env["platform"] == "android":
+        if env["android_arch"] == "arm64v8":
+            env.Append(LIBPATH=["#modules/fmod/api/core/lib/arm64-v8a", "#modules/fmod/api/studio/lib/arm64-v8a"])
+        else:
+            env.Append(LIBPATH=["#modules/fmod/api/core/lib/armeabi-v7a", "#modules/fmod/api/studio/lib/armeabi-v7a"])
+        env.Append(LIBS=["fmod", "fmodstudio"])


### PR DESCRIPTION
This enable to build godot engine with fmod module for android.
Only armv8 and armv7 are supported, as x86 and x64 does not represents a significative part of android devices.