### PR TITLE
Update/remove UUID dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ __pycache__
 
 demo/.import/
 demo/test_sounds/
+
+.vscode

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 A Godot C++ module that provides an integration and GDScript bindings for the FMOD Studio API.
 
-FMOD is an audio engine and middleware solution for interactive audio in games. It has been the audio engine behind many titles such as Transistor, Pyre and Celeste. [More on FMOD's website](https://www.fmod.com/).
+FMOD is an audio engine and middleware solution for interactive audio in games. It has been the audio engine behind many titles such as Transistor, Into the Breach and Celeste. [More on FMOD's website](https://www.fmod.com/).
 
 This module exposes most of the Studio API functions to Godot's GDScript and also provides helpers for performing common functions like attaching Studio events to Godot nodes and playing 3D/positional audio. _It is still very much a work in progress and some API functions are not yet exposed._ Feel free to tweak/extend it based on your project's needs.
 
-**Note:** FMOD provides a C# wrapper for their API which is used in the Unity integration and it is possible to use the same wrapper to build an integration for Godot in C#. However do note that this would only work on a Mono build of Godot and performance might not be on the same level as a Native/C++ integration. 
+**Note:** FMOD also provides a C# wrapper for their API which is used in the Unity integration and it is possible to use the same wrapper to build an integration for Godot in C#. However do note that this would only work on a Mono build of Godot and performance might not be on the same level as a Native/C++ integration.
 
 ## Installing the module
 
@@ -16,7 +16,6 @@ This module exposes most of the Studio API functions to Godot's GDScript and als
 4. Copy the contents of the `api` directory of the FMOD API into the module's `api` directory `modules/fmod/api`. On Windows this is (usually) found at `C:/Program Files (x86)/FMOD SoundSystem/FMOD Studio API Windows/api`.
 5. Recompile the engine. For more information on compiling the engine, refer to the [Godot documentation](https://docs.godotengine.org/en/latest/development/compiling/index.html).
 6. Place the FMOD library files within the `bin` directory for Godot to start. Eg. on Windows these would be `fmod.dll` and `fmodstudio.dll`. When shipping, these files have to be included with the release.
-
 
 ## Using the module
 
@@ -61,16 +60,12 @@ func _process(delta):
 
 ### Calling Studio events
 
-Following is an example of an event instance called manually (ie. not directly managed by the integration). These instances are identified by a unique ID in the form of a string that you must generate in script ideally through a UUID generator. You could write one yourself or use something like [UUID for Godot](https://github.com/binogure-studio/godot-uuid). Note that the string could be anything as long as it is unique within the current instance pool. Remember to release the instance once you're done with it.
+One-shots are great for quick sounds which you would want to simply fire and forget. But what about something a bit more complex like a looping sound or an interactive music event with a bunch of states? Here's an example of a Studio event called manually (ie. not directly managed by the integration). You can then call functions on that specific instance such as setting parameters. Remember to release the instance once you're done with it!
 
 ```gdscript
-# unique identifier used to id your event instance
-# throughout its lifecycle
-var my_music_event = UUID.new()
-
-# create an event instance associated with the unique identifier
+# create an event instance
 # this is a music event that has been authored in the Studio editor
-FMOD.event_create_instance(my_music_event, "event:/Waveshaper - Wisdom of Rage")
+var my_music_event = FMOD.event_create_instance("event:/Waveshaper - Wisdom of Rage")
 
 # start the event
 FMOD.event_start(my_music_event)
@@ -125,11 +120,11 @@ FMOD.detach_instance_from_node(uuid)
 
 ### Playing sounds using FMOD Core / Low Level API
 
-You can load and play any sound file in your project directory by using the FMOD Low Level API bindings. Similar to Studio Events these instances are identified by a UUID generated in script. Any instances you create must be released manually. Refer to FMOD's documentation pages for a list of compatible sound formats.
+You can load and play any sound file in your project directory by using the FMOD Low Level API bindings. Similar to Studio events these instances have to be released manually. Refer to FMOD's documentation pages for a list of compatible sound formats.
 
 ```gdscript
-# note that this function returns the UUID back to you as its return value
-var my_sound = FMOD.sound_load(UUID.new(), "./ta-da.wav", Fmod.FMOD_DEFAULT)
+# create a sound
+var my_sound = FMOD.sound_load("./ta-da.wav", Fmod.FMOD_DEFAULT)
 
 FMOD.sound_play(my_sound)
 
@@ -150,16 +145,19 @@ In order to get FMOD working on Android, you need to make Fmod java static initi
 template. To do so, follow the next steps.
 
 - Add fmod.jar as dependency in your project.
-In order to add FMOD to Gradle you should have dependencies looking like this :  
+  In order to add FMOD to Gradle you should have dependencies looking like this :
+
 ```
 dependencies {
 	implementation "com.android.support:support-core-utils:28.0.0"
 	compile files("libs/fmod.jar")
 }
 ```
-- Modify `onCreate` and `onDestroy` methods in `Godot` Java class  
 
-For `onCreate` you should initialize Java part of FMOD.  
+- Modify `onCreate` and `onDestroy` methods in `Godot` Java class
+
+For `onCreate` you should initialize Java part of FMOD.
+
 ```java
 	@Override
 	protected void onCreate(Bundle icicle) {
@@ -172,6 +170,7 @@ For `onCreate` you should initialize Java part of FMOD.
 ```
 
 For `onDestroy` method, you should close Java part of FMOD.
+
 ```java
 	@Override
 	protected void onDestroy() {
@@ -186,7 +185,7 @@ For `onDestroy` method, you should close Java part of FMOD.
 ```
 
 - Then run `./gradlew build` to generate an apk export template. You can then use it in your project to get FMOD working
-on Android.
+  on Android.
 
 ## Issues
 

--- a/README.md
+++ b/README.md
@@ -112,10 +112,10 @@ FMOD.play_one_shot_attached_with_params("event:/Footstep", self, { "Surface": 1.
 
 # attaches a manually called instance to a Node
 # once attached 3D attributes are automatically set every frame (when update is called)
-FMOD.attach_instance_to_node(uuid, self)
+FMOD.attach_instance_to_node(event_instance, self)
 
 # detaches the instance from its Node
-FMOD.detach_instance_from_node(uuid)
+FMOD.detach_instance_from_node(event_instance)
 ```
 
 ### Playing sounds using FMOD Core / Low Level API

--- a/demo/Scripts/FMOD.gd
+++ b/demo/Scripts/FMOD.gd
@@ -78,8 +78,8 @@ func bank_get_vca_count(path_to_bank):
 	
 
 ##### event functions #####
-func event_create_instance(uuid, event_path):
-	return FMOD.event_create_instance(uuid, event_path)
+func event_create_instance(event_path):
+	return FMOD.event_create_instance(event_path)
 	
 func event_get_parameter(uuid, parameter_name):
 	return FMOD.event_get_parameter(uuid, parameter_name)
@@ -167,8 +167,8 @@ func vca_set_volume(path_to_vca, volume):
 	return FMOD.vca_set_volume(path_to_vca, volume)
 	
 ##### Sound functions #####
-func sound_load(uuid, path_to_sound, mode):
-	return FMOD.sound_load(uuid, path_to_sound, mode)
+func sound_load(path_to_sound, mode):
+	return FMOD.sound_load(path_to_sound, mode)
 	
 func sound_play(uuid):
 	return FMOD.sound_play(uuid)

--- a/godot_fmod.cpp
+++ b/godot_fmod.cpp
@@ -228,8 +228,7 @@ int Fmod::getBankVCACount(const String &pathToBank) {
 	return -1;
 }
 
-String Fmod::createEventInstance(const String &uuid, const String &eventPath) {
-	if (unmanagedEvents.has(uuid)) return uuid; // provided uuid is not valid
+unsigned int Fmod::createEventInstance(const String &eventPath) {
 	if (!eventDescriptions.has(eventPath)) {
 		FMOD::Studio::EventDescription *desc = nullptr;
 		checkErrors(system->getEvent(eventPath.ascii().get_data(), &desc));
@@ -238,58 +237,61 @@ String Fmod::createEventInstance(const String &uuid, const String &eventPath) {
 	auto desc = eventDescriptions.find(eventPath);
 	FMOD::Studio::EventInstance *instance;
 	checkErrors(desc->value()->createInstance(&instance));
-	if (instance)
-		unmanagedEvents.insert(uuid, instance);
-	return uuid;
+	if (instance) {
+		unsigned int instanceId = instanceIdCount + 1;
+		unmanagedEvents.insert(instanceId, instance);
+		return instanceId;
+	}
+	return 0;
 }
 
-float Fmod::getEventParameter(const String &uuid, const String &parameterName) {
+float Fmod::getEventParameter(unsigned int instanceId, const String &parameterName) {
 	float p = -1;
-	if (!unmanagedEvents.has(uuid)) return p;
-	auto i = unmanagedEvents.find(uuid);
+	if (!unmanagedEvents.has(instanceId)) return p;
+	auto i = unmanagedEvents.find(instanceId);
 	if (i->value())
 		checkErrors(i->value()->getParameterByName(parameterName.ascii().get_data(), &p));
 	return p;
 }
 
-void Fmod::setEventParameter(const String &uuid, const String &parameterName, float value) {
-	if (!unmanagedEvents.has(uuid)) return;
-	auto i = unmanagedEvents.find(uuid);
+void Fmod::setEventParameter(unsigned int instanceId, const String &parameterName, float value) {
+	if (!unmanagedEvents.has(instanceId)) return;
+	auto i = unmanagedEvents.find(instanceId);
 	if (i->value()) checkErrors(i->value()->setParameterByName(parameterName.ascii().get_data(), value));
 }
 
-void Fmod::releaseEvent(const String &uuid) {
-	if (!unmanagedEvents.has(uuid)) return;
-	auto i = unmanagedEvents.find(uuid);
+void Fmod::releaseEvent(unsigned int instanceId) {
+	if (!unmanagedEvents.has(instanceId)) return;
+	auto i = unmanagedEvents.find(instanceId);
 	if (i->value()) checkErrors(i->value()->release());
 }
 
-void Fmod::startEvent(const String &uuid) {
-	if (!unmanagedEvents.has(uuid)) return;
-	auto i = unmanagedEvents.find(uuid);
+void Fmod::startEvent(unsigned int instanceId) {
+	if (!unmanagedEvents.has(instanceId)) return;
+	auto i = unmanagedEvents.find(instanceId);
 	if (i->value()) checkErrors(i->value()->start());
 }
 
-void Fmod::stopEvent(const String &uuid, int stopMode) {
-	if (!unmanagedEvents.has(uuid)) return;
-	auto i = unmanagedEvents.find(uuid);
+void Fmod::stopEvent(unsigned int instanceId, int stopMode) {
+	if (!unmanagedEvents.has(instanceId)) return;
+	auto i = unmanagedEvents.find(instanceId);
 	if (i->value()) {
 		auto m = static_cast<FMOD_STUDIO_STOP_MODE>(stopMode);
 		checkErrors(i->value()->stop(m));
 	}
 }
 
-void Fmod::triggerEventCue(const String &uuid) {
-	if (!unmanagedEvents.has(uuid)) return;
-	auto i = unmanagedEvents.find(uuid);
+void Fmod::triggerEventCue(unsigned int instanceId) {
+	if (!unmanagedEvents.has(instanceId)) return;
+	auto i = unmanagedEvents.find(instanceId);
 	if (i->value()) checkErrors(i->value()->triggerCue());
 }
 
-int Fmod::getEventPlaybackState(const String &uuid) {
-	if (!unmanagedEvents.has(uuid))
+int Fmod::getEventPlaybackState(unsigned int instanceId) {
+	if (!unmanagedEvents.has(instanceId))
 		return -1;
 	else {
-		auto i = unmanagedEvents.find(uuid);
+		auto i = unmanagedEvents.find(instanceId);
 		if (i->value()) {
 			FMOD_STUDIO_PLAYBACK_STATE s;
 			checkErrors(i->value()->getPlaybackState(&s));
@@ -299,79 +301,79 @@ int Fmod::getEventPlaybackState(const String &uuid) {
 	}
 }
 
-bool Fmod::getEventPaused(const String &uuid) {
-	if (!unmanagedEvents.has(uuid)) return false;
-	auto i = unmanagedEvents.find(uuid);
+bool Fmod::getEventPaused(unsigned int instanceId) {
+	if (!unmanagedEvents.has(instanceId)) return false;
+	auto i = unmanagedEvents.find(instanceId);
 	bool paused = false;
 	if (i->value()) checkErrors(i->value()->getPaused(&paused));
 	return paused;
 }
 
-void Fmod::setEventPaused(const String &uuid, bool paused) {
-	if (!unmanagedEvents.has(uuid)) return;
-	auto i = unmanagedEvents.find(uuid);
+void Fmod::setEventPaused(unsigned int instanceId, bool paused) {
+	if (!unmanagedEvents.has(instanceId)) return;
+	auto i = unmanagedEvents.find(instanceId);
 	if (i->value()) checkErrors(i->value()->setPaused(paused));
 }
 
-float Fmod::getEventPitch(const String &uuid) {
-	if (!unmanagedEvents.has(uuid)) return 0.0f;
-	auto i = unmanagedEvents.find(uuid);
+float Fmod::getEventPitch(unsigned int instanceId) {
+	if (!unmanagedEvents.has(instanceId)) return 0.0f;
+	auto i = unmanagedEvents.find(instanceId);
 	float pitch = 0.0f;
 	if (i->value()) checkErrors(i->value()->getPitch(&pitch));
 	return pitch;
 }
 
-void Fmod::setEventPitch(const String &uuid, float pitch) {
-	if (!unmanagedEvents.has(uuid)) return;
-	auto i = unmanagedEvents.find(uuid);
+void Fmod::setEventPitch(unsigned int instanceId, float pitch) {
+	if (!unmanagedEvents.has(instanceId)) return;
+	auto i = unmanagedEvents.find(instanceId);
 	if (i->value()) checkErrors(i->value()->setPitch(pitch));
 }
 
-float Fmod::getEventVolume(const String &uuid) {
-	if (!unmanagedEvents.has(uuid)) return 0.0f;
-	auto i = unmanagedEvents.find(uuid);
+float Fmod::getEventVolume(unsigned int instanceId) {
+	if (!unmanagedEvents.has(instanceId)) return 0.0f;
+	auto i = unmanagedEvents.find(instanceId);
 	float volume = 0.0f;
 	if (i->value()) checkErrors(i->value()->getVolume(&volume));
 	return volume;
 }
 
-void Fmod::setEventVolume(const String &uuid, float volume) {
-	if (!unmanagedEvents.has(uuid)) return;
-	auto i = unmanagedEvents.find(uuid);
+void Fmod::setEventVolume(unsigned int instanceId, float volume) {
+	if (!unmanagedEvents.has(instanceId)) return;
+	auto i = unmanagedEvents.find(instanceId);
 	if (i->value()) checkErrors(i->value()->setVolume(volume));
 }
 
-int Fmod::getEventTimelinePosition(const String &uuid) {
-	if (!unmanagedEvents.has(uuid)) return 0;
-	auto i = unmanagedEvents.find(uuid);
+int Fmod::getEventTimelinePosition(unsigned int instanceId) {
+	if (!unmanagedEvents.has(instanceId)) return 0;
+	auto i = unmanagedEvents.find(instanceId);
 	int tp = 0;
 	if (i->value()) checkErrors(i->value()->getTimelinePosition(&tp));
 	return tp;
 }
 
-void Fmod::setEventTimelinePosition(const String &uuid, int position) {
-	if (!unmanagedEvents.has(uuid)) return;
-	auto i = unmanagedEvents.find(uuid);
+void Fmod::setEventTimelinePosition(unsigned int instanceId, int position) {
+	if (!unmanagedEvents.has(instanceId)) return;
+	auto i = unmanagedEvents.find(instanceId);
 	if (i->value()) checkErrors(i->value()->setTimelinePosition(position));
 }
 
-float Fmod::getEventReverbLevel(const String &uuid, int index) {
-	if (!unmanagedEvents.has(uuid)) return 0.0f;
-	auto i = unmanagedEvents.find(uuid);
+float Fmod::getEventReverbLevel(unsigned int instanceId, int index) {
+	if (!unmanagedEvents.has(instanceId)) return 0.0f;
+	auto i = unmanagedEvents.find(instanceId);
 	float rvl = 0.0f;
 	if (i->value()) checkErrors(i->value()->getReverbLevel(index, &rvl));
 	return rvl;
 }
 
-void Fmod::setEventReverbLevel(const String &uuid, int index, float level) {
-	if (!unmanagedEvents.has(uuid)) return;
-	auto i = unmanagedEvents.find(uuid);
+void Fmod::setEventReverbLevel(unsigned int instanceId, int index, float level) {
+	if (!unmanagedEvents.has(instanceId)) return;
+	auto i = unmanagedEvents.find(instanceId);
 	if (i->value()) checkErrors(i->value()->setReverbLevel(index, level));
 }
 
-bool Fmod::isEventVirtual(const String &uuid) {
-	if (!unmanagedEvents.has(uuid)) return false;
-	auto i = unmanagedEvents.find(uuid);
+bool Fmod::isEventVirtual(unsigned int instanceId) {
+	if (!unmanagedEvents.has(instanceId)) return false;
+	auto i = unmanagedEvents.find(instanceId);
 	bool v = false;
 	if (i->value()) checkErrors(i->value()->isVirtual(&v));
 	return v;
@@ -568,18 +570,18 @@ void Fmod::playOneShotAttachedWithParams(const String &eventName, Object *gameOb
 	}
 }
 
-void Fmod::attachInstanceToNode(const String &uuid, Object *gameObj) {
-	if (!unmanagedEvents.has(uuid) || isNull(gameObj)) return;
-	auto i = unmanagedEvents.find(uuid);
+void Fmod::attachInstanceToNode(unsigned int instanceId, Object *gameObj) {
+	if (!unmanagedEvents.has(instanceId) || isNull(gameObj)) return;
+	auto i = unmanagedEvents.find(instanceId);
 	if (i->value()) {
 		AttachedOneShot aShot = { i->value(), gameObj };
 		attachedOneShots.push_back(aShot);
 	}
 }
 
-void Fmod::detachInstanceFromNode(const String &uuid) {
-	if (!unmanagedEvents.has(uuid)) return;
-	auto instance = unmanagedEvents.find(uuid);
+void Fmod::detachInstanceFromNode(unsigned int instanceId) {
+	if (!unmanagedEvents.has(instanceId)) return;
+	auto instance = unmanagedEvents.find(instanceId);
 	if (instance->value()) {
 		for (int i = 0; attachedOneShots.size(); i++) {
 			auto attachedInstance = attachedOneShots.get(i).instance;
@@ -607,33 +609,33 @@ void Fmod::setVCAVolume(const String &VCAPath, float volume) {
 	checkErrors(vca->value()->setVolume(volume));
 }
 
-void Fmod::playSound(const String &uuid) {
-	if (sounds.has(uuid)) {
-		auto s = sounds.find(uuid)->value();
+void Fmod::playSound(unsigned int instanceId) {
+	if (sounds.has(instanceId)) {
+		auto s = sounds.find(instanceId)->value();
 		auto c = channels.find(s)->value();
 		checkErrors(c->setPaused(false));
 	}
 }
 
-void Fmod::setSoundPaused(const String &uuid, bool paused) {
-	if (sounds.has(uuid)) {
-		auto s = sounds.find(uuid)->value();
+void Fmod::setSoundPaused(unsigned int instanceId, bool paused) {
+	if (sounds.has(instanceId)) {
+		auto s = sounds.find(instanceId)->value();
 		auto c = channels.find(s)->value();
 		checkErrors(c->setPaused(paused));
 	}
 }
 
-void Fmod::stopSound(const String &uuid) {
-	if (sounds.has(uuid)) {
-		auto s = sounds.find(uuid)->value();
+void Fmod::stopSound(unsigned int instanceId) {
+	if (sounds.has(instanceId)) {
+		auto s = sounds.find(instanceId)->value();
 		auto c = channels.find(s)->value();
 		checkErrors(c->stop());
 	}
 }
 
-bool Fmod::isSoundPlaying(const String &uuid) {
-	if (sounds.has(uuid)) {
-		auto s = sounds.find(uuid)->value();
+bool Fmod::isSoundPlaying(unsigned int instanceId) {
+	if (sounds.has(instanceId)) {
+		auto s = sounds.find(instanceId)->value();
 		auto c = channels.find(s)->value();
 		bool isPlaying = false;
 		checkErrors(c->isPlaying(&isPlaying));
@@ -642,17 +644,17 @@ bool Fmod::isSoundPlaying(const String &uuid) {
 	return false;
 }
 
-void Fmod::setSoundVolume(const String &uuid, float volume) {
-	if (sounds.has(uuid)) {
-		auto s = sounds.find(uuid)->value();
+void Fmod::setSoundVolume(unsigned int instanceId, float volume) {
+	if (sounds.has(instanceId)) {
+		auto s = sounds.find(instanceId)->value();
 		auto c = channels.find(s)->value();
 		checkErrors(c->setVolume(volume));
 	}
 }
 
-float Fmod::getSoundVolume(const String &uuid) {
-	if (sounds.has(uuid)) {
-		auto s = sounds.find(uuid)->value();
+float Fmod::getSoundVolume(unsigned int instanceId) {
+	if (sounds.has(instanceId)) {
+		auto s = sounds.find(instanceId)->value();
 		auto c = channels.find(s)->value();
 		float volume = 0.f;
 		checkErrors(c->getVolume(&volume));
@@ -661,9 +663,9 @@ float Fmod::getSoundVolume(const String &uuid) {
 	return 0.f;
 }
 
-float Fmod::getSoundPitch(const String &uuid) {
-	if (sounds.has(uuid)) {
-		auto s = sounds.find(uuid)->value();
+float Fmod::getSoundPitch(unsigned int instanceId) {
+	if (sounds.has(instanceId)) {
+		auto s = sounds.find(instanceId)->value();
 		auto c = channels.find(s)->value();
 		float pitch = 0.f;
 		checkErrors(c->getPitch(&pitch));
@@ -672,31 +674,33 @@ float Fmod::getSoundPitch(const String &uuid) {
 	return 0.f;
 }
 
-void Fmod::setSoundPitch(const String &uuid, float pitch) {
-	if (sounds.has(uuid)) {
-		auto s = sounds.find(uuid)->value();
+void Fmod::setSoundPitch(unsigned int instanceId, float pitch) {
+	if (sounds.has(instanceId)) {
+		auto s = sounds.find(instanceId)->value();
 		auto c = channels.find(s)->value();
 		checkErrors(c->setPitch(pitch));
 	}
 }
 
-String Fmod::loadSound(const String &uuid, const String &path, int mode) {
-	if (!sounds.has(path)) {
-		FMOD::Sound *sound = nullptr;
-		checkErrors(coreSystem->createSound(path.ascii().get_data(), mode, nullptr, &sound));
-		if (sound) {
-			sounds.insert(uuid, sound);
-			FMOD::Channel *channel = nullptr;
-			checkErrors(coreSystem->playSound(sound, nullptr, true, &channel));
-			if (channel) channels.insert(sound, channel);
+unsigned int Fmod::loadSound(const String &path, int mode) {
+	FMOD::Sound *sound = nullptr;
+	checkErrors(coreSystem->createSound(path.ascii().get_data(), mode, nullptr, &sound));
+	if (sound) {
+		unsigned int instanceId = instanceIdCount + 1;
+		sounds.insert(instanceId, sound);
+		FMOD::Channel *channel = nullptr;
+		checkErrors(coreSystem->playSound(sound, nullptr, true, &channel));
+		if (channel) {
+			channels.insert(sound, channel);
+			return instanceId;
 		}
 	}
-	return uuid;
+	return 0;
 }
 
-void Fmod::releaseSound(const String &path) {
-	if (!sounds.has(path)) return; // sound is not loaded
-	auto sound = sounds.find(path);
+void Fmod::releaseSound(unsigned int instanceId) {
+	if (!sounds.has(instanceId)) return; // sound is not loaded
+	auto sound = sounds.find(instanceId);
 	if (sound->value()) checkErrors(sound->value()->release());
 }
 
@@ -718,15 +722,14 @@ void Fmod::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("system_set_software_format", "sample_rate", "speaker_mode", "num_raw_speakers"), &Fmod::setSoftwareFormat);
 	ClassDB::bind_method(D_METHOD("system_set_parameter", "name", "value"), &Fmod::setGlobalParameter);
 	ClassDB::bind_method(D_METHOD("system_get_parameter", "name"), &Fmod::getGlobalParameter);
-	
 
 	/* integration helper functions */
 	ClassDB::bind_method(D_METHOD("play_one_shot", "event_name", "node"), &Fmod::playOneShot);
 	ClassDB::bind_method(D_METHOD("play_one_shot_with_params", "event_name", "node", "initial_parameters"), &Fmod::playOneShotWithParams);
 	ClassDB::bind_method(D_METHOD("play_one_shot_attached", "event_name", "node"), &Fmod::playOneShotAttached);
 	ClassDB::bind_method(D_METHOD("play_one_shot_attached_with_params", "event_name", "node", "initial_parameters"), &Fmod::playOneShotAttachedWithParams);
-	ClassDB::bind_method(D_METHOD("attach_instance_to_node", "uuid", "node"), &Fmod::attachInstanceToNode);
-	ClassDB::bind_method(D_METHOD("detach_instance_from_node", "uuid"), &Fmod::detachInstanceFromNode);
+	ClassDB::bind_method(D_METHOD("attach_instance_to_node", "id", "node"), &Fmod::attachInstanceToNode);
+	ClassDB::bind_method(D_METHOD("detach_instance_from_node", "id"), &Fmod::detachInstanceFromNode);
 
 	/* bank functions */
 	ClassDB::bind_method(D_METHOD("bank_load", "path_to_bank", "flags"), &Fmod::loadbank);
@@ -738,25 +741,25 @@ void Fmod::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("bank_get_vca_count", "path_to_bank"), &Fmod::getBankVCACount);
 
 	/* event functions */
-	ClassDB::bind_method(D_METHOD("event_create_instance", "uuid", "event_path"), &Fmod::createEventInstance);
-	ClassDB::bind_method(D_METHOD("event_get_parameter", "uuid", "parameter_name"), &Fmod::getEventParameter);
-	ClassDB::bind_method(D_METHOD("event_set_parameter", "uuid", "parameter_name", "value"), &Fmod::setEventParameter);
-	ClassDB::bind_method(D_METHOD("event_release", "uuid"), &Fmod::releaseEvent);
-	ClassDB::bind_method(D_METHOD("event_start", "uuid"), &Fmod::startEvent);
-	ClassDB::bind_method(D_METHOD("event_stop", "uuid", "stop_mode"), &Fmod::stopEvent);
-	ClassDB::bind_method(D_METHOD("event_trigger_cue", "uuid"), &Fmod::triggerEventCue);
-	ClassDB::bind_method(D_METHOD("event_get_playback_state", "uuid"), &Fmod::getEventPlaybackState);
-	ClassDB::bind_method(D_METHOD("event_get_paused", "uuid"), &Fmod::getEventPaused);
-	ClassDB::bind_method(D_METHOD("event_set_paused", "uuid", "paused"), &Fmod::setEventPaused);
-	ClassDB::bind_method(D_METHOD("event_get_pitch", "uuid"), &Fmod::getEventPitch);
-	ClassDB::bind_method(D_METHOD("event_set_pitch", "uuid", "pitch"), &Fmod::setEventPitch);
-	ClassDB::bind_method(D_METHOD("event_get_volume", "uuid"), &Fmod::getEventVolume);
-	ClassDB::bind_method(D_METHOD("event_set_volume", "uuid", "volume"), &Fmod::setEventVolume);
-	ClassDB::bind_method(D_METHOD("event_get_timeline_position", "uuid"), &Fmod::getEventTimelinePosition);
-	ClassDB::bind_method(D_METHOD("event_set_timeline_position", "uuid", "position"), &Fmod::setEventTimelinePosition);
-	ClassDB::bind_method(D_METHOD("event_get_reverb_level", "uuid", "index"), &Fmod::getEventReverbLevel);
-	ClassDB::bind_method(D_METHOD("event_set_reverb_level", "uuid", "index", "level"), &Fmod::setEventReverbLevel);
-	ClassDB::bind_method(D_METHOD("event_is_virtual", "uuid"), &Fmod::isEventVirtual);
+	ClassDB::bind_method(D_METHOD("event_create_instance", "event_path"), &Fmod::createEventInstance);
+	ClassDB::bind_method(D_METHOD("event_get_parameter", "id", "parameter_name"), &Fmod::getEventParameter);
+	ClassDB::bind_method(D_METHOD("event_set_parameter", "id", "parameter_name", "value"), &Fmod::setEventParameter);
+	ClassDB::bind_method(D_METHOD("event_release", "id"), &Fmod::releaseEvent);
+	ClassDB::bind_method(D_METHOD("event_start", "id"), &Fmod::startEvent);
+	ClassDB::bind_method(D_METHOD("event_stop", "id", "stop_mode"), &Fmod::stopEvent);
+	ClassDB::bind_method(D_METHOD("event_trigger_cue", "id"), &Fmod::triggerEventCue);
+	ClassDB::bind_method(D_METHOD("event_get_playback_state", "id"), &Fmod::getEventPlaybackState);
+	ClassDB::bind_method(D_METHOD("event_get_paused", "id"), &Fmod::getEventPaused);
+	ClassDB::bind_method(D_METHOD("event_set_paused", "id", "paused"), &Fmod::setEventPaused);
+	ClassDB::bind_method(D_METHOD("event_get_pitch", "id"), &Fmod::getEventPitch);
+	ClassDB::bind_method(D_METHOD("event_set_pitch", "id", "pitch"), &Fmod::setEventPitch);
+	ClassDB::bind_method(D_METHOD("event_get_volume", "id"), &Fmod::getEventVolume);
+	ClassDB::bind_method(D_METHOD("event_set_volume", "id", "volume"), &Fmod::setEventVolume);
+	ClassDB::bind_method(D_METHOD("event_get_timeline_position", "id"), &Fmod::getEventTimelinePosition);
+	ClassDB::bind_method(D_METHOD("event_set_timeline_position", "id", "position"), &Fmod::setEventTimelinePosition);
+	ClassDB::bind_method(D_METHOD("event_get_reverb_level", "id", "index"), &Fmod::getEventReverbLevel);
+	ClassDB::bind_method(D_METHOD("event_set_reverb_level", "id", "index", "level"), &Fmod::setEventReverbLevel);
+	ClassDB::bind_method(D_METHOD("event_is_virtual", "id"), &Fmod::isEventVirtual);
 
 	/* bus functions */
 	ClassDB::bind_method(D_METHOD("bus_get_mute", "path_to_bus"), &Fmod::getBusMute);
@@ -772,16 +775,16 @@ void Fmod::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("vca_set_volume", "path_to_vca", "volume"), &Fmod::setVCAVolume);
 
 	/* Sound functions */
-	ClassDB::bind_method(D_METHOD("sound_load", "uuid", "path_to_sound", "mode"), &Fmod::loadSound);
-	ClassDB::bind_method(D_METHOD("sound_play", "uuid"), &Fmod::playSound);
-	ClassDB::bind_method(D_METHOD("sound_stop", "uuid"), &Fmod::stopSound);
-	ClassDB::bind_method(D_METHOD("sound_release", "uuid"), &Fmod::releaseSound);
-	ClassDB::bind_method(D_METHOD("sound_set_paused", "uuid", "paused"), &Fmod::setSoundPaused);
-	ClassDB::bind_method(D_METHOD("sound_is_playing", "uuid"), &Fmod::isSoundPlaying);
-	ClassDB::bind_method(D_METHOD("sound_set_volume", "uuid", "volume"), &Fmod::setSoundVolume);
-	ClassDB::bind_method(D_METHOD("sound_get_volume", "uuid"), &Fmod::getSoundVolume);
-	ClassDB::bind_method(D_METHOD("sound_set_pitch", "uuid", "pitch"), &Fmod::setSoundPitch);
-	ClassDB::bind_method(D_METHOD("sound_get_pitch", "uuid"), &Fmod::getSoundPitch);
+	ClassDB::bind_method(D_METHOD("sound_load", "path_to_sound", "mode"), &Fmod::loadSound);
+	ClassDB::bind_method(D_METHOD("sound_play", "id"), &Fmod::playSound);
+	ClassDB::bind_method(D_METHOD("sound_stop", "id"), &Fmod::stopSound);
+	ClassDB::bind_method(D_METHOD("sound_release", "id"), &Fmod::releaseSound);
+	ClassDB::bind_method(D_METHOD("sound_set_paused", "id", "paused"), &Fmod::setSoundPaused);
+	ClassDB::bind_method(D_METHOD("sound_is_playing", "id"), &Fmod::isSoundPlaying);
+	ClassDB::bind_method(D_METHOD("sound_set_volume", "id", "volume"), &Fmod::setSoundVolume);
+	ClassDB::bind_method(D_METHOD("sound_get_volume", "id"), &Fmod::getSoundVolume);
+	ClassDB::bind_method(D_METHOD("sound_set_pitch", "id", "pitch"), &Fmod::setSoundPitch);
+	ClassDB::bind_method(D_METHOD("sound_get_pitch", "id"), &Fmod::getSoundPitch);
 
 	ClassDB::bind_method(D_METHOD("system_set_sound_3d_settings", "dopplerScale", "distanceFactor", "rollOffScale"), &Fmod::setSound3DSettings);
 
@@ -871,14 +874,12 @@ void Fmod::_bind_methods() {
 	BIND_CONSTANT(FMOD_IGNORETAGS);
 	BIND_CONSTANT(FMOD_LOWMEM);
 	BIND_CONSTANT(FMOD_VIRTUAL_PLAYFROMSTART);
-
 }
 
 Fmod::Fmod() {
 	system = nullptr, coreSystem = nullptr, listener = nullptr;
 	checkErrors(FMOD::Studio::System::create(&system));
 	checkErrors(system->getCoreSystem(&coreSystem));
-	distanceScale = 1.0;
 }
 
 Fmod::~Fmod() {

--- a/godot_fmod.h
+++ b/godot_fmod.h
@@ -50,17 +50,17 @@ class Fmod : public Object {
 	FMOD::Studio::System *system;
 	FMOD::System *coreSystem;
 
-	float distanceScale;
-
 	Object *listener;
 
 	bool nullListenerWarning = true;
+	float distanceScale = 1.0f;
+	unsigned int instanceIdCount = 0;
 
 	Map<String, FMOD::Studio::Bank *> banks;
 	Map<String, FMOD::Studio::EventDescription *> eventDescriptions;
 	Map<String, FMOD::Studio::Bus *> buses;
 	Map<String, FMOD::Studio::VCA *> VCAs;
-	Map<String, FMOD::Sound *> sounds;
+	Map<unsigned int, FMOD::Sound *> sounds;
 	Map<FMOD::Sound *, FMOD::Channel *> channels;
 
 	// keep track of one shot instances internally
@@ -73,7 +73,7 @@ class Fmod : public Object {
 
 	// events not directly managed by the integration
 	// referenced through uuids generated in script
-	Map<String, FMOD::Studio::EventInstance *> unmanagedEvents;
+	Map<unsigned int, FMOD::Studio::EventInstance *> unmanagedEvents;
 
 	FMOD_3D_ATTRIBUTES get3DAttributes(FMOD_VECTOR pos, FMOD_VECTOR up, FMOD_VECTOR forward, FMOD_VECTOR vel);
 	FMOD_VECTOR toFmodVector(Vector3 vec);
@@ -94,6 +94,7 @@ public:
 	void shutdown();
 	void addListener(Object *gameObj);
 	void setSoftwareFormat(int sampleRate, int speakerMode, int numRawSpeakers);
+	void setSound3DSettings(float dopplerScale, float distanceFactor, float rollOffScale);
 	void setGlobalParameter(const String &parameterName, float value);
 	float getGlobalParameter(const String &parameterName);
 
@@ -102,8 +103,8 @@ public:
 	void playOneShotWithParams(const String &eventName, Object *gameObj, const Dictionary &parameters);
 	void playOneShotAttached(const String &eventName, Object *gameObj);
 	void playOneShotAttachedWithParams(const String &eventName, Object *gameObj, const Dictionary &parameters);
-	void attachInstanceToNode(const String &uuid, Object *gameObj);
-	void detachInstanceFromNode(const String &uuid);
+	void attachInstanceToNode(unsigned int instanceId, Object *gameObj);
+	void detachInstanceFromNode(unsigned int instanceId);
 
 	/* bank functions */
 	String loadbank(const String &pathToBank, int flags);
@@ -115,25 +116,25 @@ public:
 	int getBankVCACount(const String &pathToBank);
 
 	/* event functions */
-	String createEventInstance(const String &uuid, const String &eventPath);
-	float getEventParameter(const String &uuid, const String &parameterName);
-	void setEventParameter(const String &uuid, const String &parameterName, float value);
-	void releaseEvent(const String &uuid);
-	void startEvent(const String &uuid);
-	void stopEvent(const String &uuid, int stopMode);
-	void triggerEventCue(const String &uuid);
-	int getEventPlaybackState(const String &uuid);
-	bool getEventPaused(const String &uuid);
-	void setEventPaused(const String &uuid, bool paused);
-	float getEventPitch(const String &uuid);
-	void setEventPitch(const String &uuid, float pitch);
-	float getEventVolume(const String &uuid);
-	void setEventVolume(const String &uuid, float volume);
-	int getEventTimelinePosition(const String &uuid);
-	void setEventTimelinePosition(const String &uuid, int position);
-	float getEventReverbLevel(const String &uuid, int index);
-	void setEventReverbLevel(const String &uuid, int index, float level);
-	bool isEventVirtual(const String &uuid);
+	unsigned int createEventInstance(const String &eventPath);
+	float getEventParameter(unsigned int instanceId, const String &parameterName);
+	void setEventParameter(unsigned int instanceId, const String &parameterName, float value);
+	void releaseEvent(unsigned int instanceId);
+	void startEvent(unsigned int instanceId);
+	void stopEvent(unsigned int instanceId, int stopMode);
+	void triggerEventCue(unsigned int instanceId);
+	int getEventPlaybackState(unsigned int instanceId);
+	bool getEventPaused(unsigned int instanceId);
+	void setEventPaused(unsigned int instanceId, bool paused);
+	float getEventPitch(unsigned int instanceId);
+	void setEventPitch(unsigned int instanceId, float pitch);
+	float getEventVolume(unsigned int instanceId);
+	void setEventVolume(unsigned int instanceId, float volume);
+	int getEventTimelinePosition(unsigned int instanceId);
+	void setEventTimelinePosition(unsigned int instanceId, int position);
+	float getEventReverbLevel(unsigned int instanceId, int index);
+	void setEventReverbLevel(unsigned int instanceId, int index, float level);
+	bool isEventVirtual(unsigned int instanceId);
 
 	/* bus functions */
 	bool getBusMute(const String &busPath);
@@ -149,18 +150,16 @@ public:
 	void setVCAVolume(const String &VCAPath, float volume);
 
 	/* Sound functions */
-	void playSound(const String &uuid);
-	String loadSound(const String &uuid, const String &path, int mode);
-	void releaseSound(const String &path);
-	void setSoundPaused(const String &uuid, bool paused);
-	void stopSound(const String &uuid);
-	bool isSoundPlaying(const String &uuid);
-	void setSoundVolume(const String &uuid, float volume);
-	float getSoundVolume(const String &uuid);
-	float getSoundPitch(const String &uuid);
-	void setSoundPitch(const String &uuid, float pitch);
-
-	void setSound3DSettings(float dopplerScale, float distanceFactor, float rollOffScale);
+	void playSound(unsigned int instanceId);
+	unsigned int loadSound(const String &path, int mode);
+	void releaseSound(unsigned int instanceId);
+	void setSoundPaused(unsigned int instanceId, bool paused);
+	void stopSound(unsigned int instanceId);
+	bool isSoundPlaying(unsigned int instanceId);
+	void setSoundVolume(unsigned int instanceId, float volume);
+	float getSoundVolume(unsigned int instanceId);
+	float getSoundPitch(unsigned int instanceId);
+	void setSoundPitch(unsigned int instanceId, float pitch);	
 
 	Fmod();
 	~Fmod();


### PR DESCRIPTION
Previously this project had to rely on external dependencies to generate UUIDs but this is no longer the case. The integration will generate and keep track of IDs internally now. I initially wanted to use pointers cast to integers but this seemed a bit difficult to marshal back and forth so sticking to unsigned integers instead. This should greatly simplify the whole scripting process now that the extra responsibility of tracking IDs is taken care of by the integration.