### PR TITLE
Fixed Windows compilation by renaming fmod lib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,8 +74,6 @@ install:
   - if [[ "$PLATFORM" == "osx" ]]; then hdiutil attach fmodstudioapi20002osx.dmg; fi
   - if [[ "$PLATFORM" == "windows" ]]; then
     7z x fmodstudioapi20002win-installer.exe;
-    mv api/core/lib/x64/fmod_vc.lib api/core/lib/x64/fmod64_vc.windows.tools.64.lib;
-    mv api/studio/lib/x64/fmodstudio_vc.lib api/studio/lib/x64/fmodstudio64_vc.windows.tools.64.lib;
     fi
   - if [[ "$PLATFORM" == "iphone" ]]; then hdiutil attach fmodstudioapi20002ios.dmg; fi
   - if [[ "$PLATFORM" == "android" ]]; then tar -xvf fmodstudioapi20002android.tar.gz; fi

--- a/config.py
+++ b/config.py
@@ -1,3 +1,5 @@
+import os
+
 def can_build(env, platform):
     return platform == "x11" or platform == "windows" or platform == "osx" or platform == "android" or platform == "iphone"
 
@@ -6,12 +8,30 @@ def configure(env):
     if env["platform"] == "windows":
         if env["bits"] == "32":
             env.Append(LIBPATH=["#modules/fmod/api/core/lib/x86/",
-                                "#modules/fmod/api/studio/lib/x86/"])
+                                "#modules/fmod/api/studio/lib/x86/"])       
+            try:
+                old_core_file = os.path.join("modules/fmod/api/core/lib/x86/", "fmod_vc.lib")
+                new_core_file = os.path.join("modules/fmod/api/core/lib/x86/", "fmod_vc.windows.opt.tools.32.lib")
+                os.rename(old_core_file, new_core_file)
+                old_studio_file = os.path.join("modules/fmod/api/studio/lib/x86/", "fmodstudio_vc.lib")
+                new_studio_file = os.path.join("modules/fmod/api/studio/lib/x86/", "fmodstudio_vc.windows.opt.tools.32.lib")
+                os.rename(old_studio_file, new_studio_file)
+            except:
+                print("Fmod libraries already renamed")
             env.Append(LIBS=["fmod_vc", "fmodstudio_vc"])
         else:
             env.Append(LIBPATH=["#modules/fmod/api/core/lib/x64/",
-                                "#modules/fmod/api/studio/lib/x64/"])
-            env.Append(LIBS=["fmod64_vc", "fmodstudio64_vc"])
+                                "#modules/fmod/api/studio/lib/x64/"])               
+            try:
+                old_core_file = os.path.join("modules/fmod/api/core/lib/x64/", "fmod_vc.lib")
+                new_core_file = os.path.join("modules/fmod/api/core/lib/x64/", "fmod_vc.windows.opt.tools.64.lib")
+                os.rename(old_core_file, new_core_file)
+                old_studio_file = os.path.join("modules/fmod/api/studio/lib/x64/", "fmodstudio_vc.lib")
+                new_studio_file = os.path.join("modules/fmod/api/studio/lib/x64/", "fmodstudio_vc.windows.opt.tools.64.lib")
+                os.rename(old_studio_file, new_studio_file)
+            except:
+                print("Fmod libraries already renamed")
+            env.Append(LIBS=["fmod_vc", "fmodstudio_vc"])
 
     elif env["platform"] == "x11":
         env.Append(LIBS=["fmod", "fmodstudio"])


### PR DESCRIPTION
I moved the renaming of Fmod libraries from travis.yml to config.py.
It will be easier to manually compile the module.